### PR TITLE
fix: apply timeouts to all requests

### DIFF
--- a/osisoft/pidevclub/piwebapi/api_client.py
+++ b/osisoft/pidevclub/piwebapi/api_client.py
@@ -136,7 +136,8 @@ class ApiClient(object):
         response_data = self.request(method, url,
                                      query_params=query_params,
                                      headers=header_params,
-                                     body=body)
+                                     body=body,
+                                     timeout=_request_timeout)
 
         return_data = response_data
         if _preload_content:
@@ -321,12 +322,13 @@ class ApiClient(object):
         thread.start()
         return thread
 
-    def request(self, method, url, query_params=None, headers=None, body=None):
+    def request(self, method, url, query_params=None, headers=None, body=None, timeout=None):
 
         return self.rest_client.send_request(url, method,
                                     body=body,
                                     query_params=query_params,
-                                    headers=headers)
+                                    headers=headers,
+                                    timeout=timeout)
 
 
 

--- a/osisoft/pidevclub/piwebapi/rest.py
+++ b/osisoft/pidevclub/piwebapi/rest.py
@@ -45,7 +45,7 @@ class RESTClientObject(object):
         self.verifySsl = verifySsl
 
 
-    def send_request(self, url, method, body, headers=None,query_params=None):
+    def send_request(self, url, method, body, headers=None, query_params=None, timeout=None):
 
         """
         Makes the HTTP request using RESTClient.
@@ -53,7 +53,8 @@ class RESTClientObject(object):
         if query_params:
             url += '?' + urlencode(query_params)
 
-        timeout = (60, 3600) # 1 minute connection timeout; 1 hour response timeout
+        if timeout is None:
+            timeout = (60, 3600) # 1 minute connection timeout; 1 hour response timeout
 
         if method == "GET":
             response = requests.get(url, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)

--- a/osisoft/pidevclub/piwebapi/rest.py
+++ b/osisoft/pidevclub/piwebapi/rest.py
@@ -53,20 +53,22 @@ class RESTClientObject(object):
         if query_params:
             url += '?' + urlencode(query_params)
 
+        timeout = (60, 3600) # 1 minute connection timeout; 1 hour response timeout
+
         if method == "GET":
-            response = requests.get(url, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.get(url, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "HEAD":
-            response = requests.head(url, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.head(url, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "OPTIONS":
-            response = requests.options(url, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.options(url, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "POST":
-            response = requests.post(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.post(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "PUT":
-            response = requests.put(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.put(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "PATCH":
-            response = requests.patch(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.patch(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "DELETE":
-            response = requests.delete(url, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.delete(url, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         else:
             raise ValueError(
                 "http method must be `GET`, `HEAD`, `OPTIONS`,"

--- a/osisoft/pidevclub/piwebapi/rest.py
+++ b/osisoft/pidevclub/piwebapi/rest.py
@@ -54,7 +54,7 @@ class RESTClientObject(object):
             url += '?' + urlencode(query_params)
 
         if timeout is None:
-            timeout = (60, 3600) # 1 minute connection timeout; 1 hour response timeout
+            timeout = (60, 600) # 1 minute connection timeout; 10 minute response timeout
 
         if method == "GET":
             response = requests.get(url, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)


### PR DESCRIPTION
The scheduled invocation of the `update_device_id_location` function is intermittently failing with the following error:
```
HTTPSConnectionPool(host='10.1.192.13', port=443): Max retries exceeded with url: /piwebapi/attributes?path=%5C%5CPI-ASSET-FMWK%5CEH2-internal%5CNatick%5CBattery1%5CStack2%7CID+2 (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x7fbf482d9a20>, 'Connection to 10.1.192.13 timed out. (connect timeout=None)'))
```

My understanding is that when a timeout is not provided, it uses a value that can vary depending on the host system. That could potentially explain why this error is less frequent in the GCP Cloud Function. 

The pi web api client methods do appear to accept `_request_timeout` arguments, but if my reading of the code is correct, that argument is never actually passed all the way to `RESTClientObject.send_request()`, where the requests are ultimately sent. If I'm not mistaken about that, then there's no way to set a timeout value without using our fork of the pi web api client repo.

I made [a branch in lims-python](https://github.com/Electric-Hydrogen/lims-python/compare/main...debugging-timeout-error) to test this and deployed it to staging. No errors so far, but I'll need to let it run for a while before deciding that it might have made a difference.

Side note: I had to increase the task resources in the staging ECS config to match prod, because the task was dying with an OOM error in staging. That means we're probably using most of the available memory in prod. We should either increase the resources in prod or refactor `update_device_id_location` to pull less data (or less data at once).